### PR TITLE
add feature transpile to protobuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-Convert TS interfaces to Rust serde.
-Use with `cargo run <ts_file>`
+Convert TS interfaces to Rust serde or Protobuf.
+Use with `cargo +nightly run <ts_file> rust` for Rust serde.
+Use with `cargo +nightly run <ts_file> proto` for Protobuf.

--- a/example_output_proto
+++ b/example_output_proto
@@ -1,223 +1,223 @@
 message CreateLoanScheme {
-  min_col_ratio int64 = 0;
-  interest_rate int64 = 1;
-  id string = 2;
+   int64 min_col_ratio = 0;
+   int64 interest_rate = 1;
+   string id = 2;
 }
 
 message UpdateLoanScheme {
-  min_col_ratio int64 = 0;
-  interest_rate int64 = 1;
-  id string = 2;
-  activate_after_block int64 = 3;
+   int64 min_col_ratio = 0;
+   int64 interest_rate = 1;
+   string id = 2;
+   int64 activate_after_block = 3;
 }
 
 message DestroyLoanScheme {
-  id string = 0;
-  activate_after_block int64 = 1;
+   string id = 0;
+   int64 activate_after_block = 1;
 }
 
 message LoanSchemeResult {
-  id string = 0;
-  mincolratio int64 = 1;
-  interestrate int64 = 2;
-  default bool = 3;
+   string id = 0;
+   int64 mincolratio = 1;
+   int64 interestrate = 2;
+   bool default = 3;
 }
 
 message SetCollateralToken {
-  token string = 0;
-  factor int64 = 1;
-  fixed_interval_price_id string = 2;
-  activate_after_block int64 = 3;
+   string token = 0;
+   int64 factor = 1;
+   string fixed_interval_price_id = 2;
+   int64 activate_after_block = 3;
 }
 
 message GetLoanSchemeResult {
-  id string = 0;
-  interestrate int64 = 1;
-  mincolratio int64 = 2;
-  default bool = 3;
+   string id = 0;
+   int64 interestrate = 1;
+   int64 mincolratio = 2;
+   bool default = 3;
 }
 
 message ListCollateralTokens {
-  height int64 = 0;
-  all bool = 1;
+   int64 height = 0;
+   bool all = 1;
 }
 
 message CollateralTokenDetail {
-  token string = 0;
-  factor int64 = 1;
-  fixed_interval_price_id string = 2;
-  activate_after_block int64 = 3;
-  token_id string = 4;
+   string token = 0;
+   int64 factor = 1;
+   string fixed_interval_price_id = 2;
+   int64 activate_after_block = 3;
+   string token_id = 4;
 }
 
 message SetLoanToken {
-  symbol string = 0;
-  name string = 1;
-  fixed_interval_price_id string = 2;
-  mintable bool = 3;
-  interest int64 = 4;
+   string symbol = 0;
+   string name = 1;
+   string fixed_interval_price_id = 2;
+   bool mintable = 3;
+   int64 interest = 4;
 }
 
 message LoanConfig {
-  fixed_interval_blocks int64 = 0;
-  max_price_deviation_pct int64 = 1;
-  min_oracles_per_price int64 = 2;
-  scheme string = 3;
+   int64 fixed_interval_blocks = 0;
+   int64 max_price_deviation_pct = 1;
+   int64 min_oracles_per_price = 2;
+   string scheme = 3;
 }
 
 message LoanSummary {
-  collateral_tokens int64 = 0;
-  collateral_value int64 = 1;
-  loan_tokens int64 = 2;
-  loan_value int64 = 3;
-  open_auctions int64 = 4;
-  open_vaults int64 = 5;
-  schemes int64 = 6;
+   int64 collateral_tokens = 0;
+   int64 collateral_value = 1;
+   int64 loan_tokens = 2;
+   int64 loan_value = 3;
+   int64 open_auctions = 4;
+   int64 open_vaults = 5;
+   int64 schemes = 6;
 }
 
 message GetLoanInfoResult {
-  current_price_block int64 = 0;
-  next_price_block int64 = 1;
-  defaults LoanConfig = 2;
-  totals LoanSummary = 3;
+   int64 current_price_block = 0;
+   int64 next_price_block = 1;
+   LoanConfig defaults = 2;
+   LoanSummary totals = 3;
 }
 
 message UpdateLoanToken {
-  symbol string = 0;
-  name string = 1;
-  fixed_interval_price_id string = 2;
-  mintable bool = 3;
-  interest int64 = 4;
+   string symbol = 0;
+   string name = 1;
+   string fixed_interval_price_id = 2;
+   bool mintable = 3;
+   int64 interest = 4;
 }
 
 message Interest {
-  token string = 0;
-  realized_interest_per_block int64 = 1;
-  total_interest int64 = 2;
-  interest_per_block int64 = 3;
+   string token = 0;
+   int64 realized_interest_per_block = 1;
+   int64 total_interest = 2;
+   int64 interest_per_block = 3;
 }
 
 message CreateVault {
-  owner_address string = 0;
-  loan_scheme_id string = 1;
+   string owner_address = 0;
+   string loan_scheme_id = 1;
 }
 
 message UpdateVault {
-  owner_address string = 0;
-  loan_scheme_id string = 1;
+   string owner_address = 0;
+   string loan_scheme_id = 1;
 }
 
 message Vault {
-  vault_id string = 0;
-  loan_scheme_id string = 1;
-  owner_address string = 2;
-  state VaultState = 3;
+   string vault_id = 0;
+   string loan_scheme_id = 1;
+   string owner_address = 2;
+   VaultState state = 3;
 }
 
 message VaultActive {
-  collateral_amounts repeated string = 0;
-  loan_amounts repeated string = 1;
-  interest_amounts repeated string = 2;
-  collateral_value int64 = 3;
-  loan_value int64 = 4;
-  interest_value int64 = 5;
-  collateral_ratio int64 = 6;
-  informative_ratio int64 = 7;
+  repeated string collateral_amounts = 0;
+  repeated string loan_amounts = 1;
+  repeated string interest_amounts = 2;
+   int64 collateral_value = 3;
+   int64 loan_value = 4;
+   int64 interest_value = 5;
+   int64 collateral_ratio = 6;
+   int64 informative_ratio = 7;
 }
 
 message VaultLiquidation {
-  liquidation_height int64 = 0;
-  liquidation_penalty int64 = 1;
-  batch_count int64 = 2;
-  batches repeated VaultLiquidationBatch = 3;
+   int64 liquidation_height = 0;
+   int64 liquidation_penalty = 1;
+   int64 batch_count = 2;
+  repeated VaultLiquidationBatch batches = 3;
 }
 
 message UTXO {
-  txid string = 0;
-  vout int64 = 1;
+   string txid = 0;
+   int64 vout = 1;
 }
 
 message DepositVault {
-  vault_id string = 0;
-  from string = 1;
-  amount string = 2;
+   string vault_id = 0;
+   string from = 1;
+   string amount = 2;
 }
 
 message WithdrawVault {
-  vault_id string = 0;
-  to string = 1;
-  amount string = 2;
+   string vault_id = 0;
+   string to = 1;
+   string amount = 2;
 }
 
 message PaybackLoanMetadataV2 {
-  vault_id string = 0;
-  from string = 1;
-  loans repeated TokenPaybackAmount = 2;
+   string vault_id = 0;
+   string from = 1;
+  repeated TokenPaybackAmount loans = 2;
 }
 
 message VaultPagination {
-  start string = 0;
-  including_start bool = 1;
-  limit int64 = 2;
+   string start = 0;
+   bool including_start = 1;
+   int64 limit = 2;
 }
 
 message ListVaultOptions {
-  owner_address string = 0;
-  loan_scheme_id string = 1;
-  state VaultState = 2;
-  verbose bool = 3;
+   string owner_address = 0;
+   string loan_scheme_id = 1;
+   VaultState state = 2;
+   bool verbose = 3;
 }
 
 message CloseVault {
-  vault_id string = 0;
-  to string = 1;
+   string vault_id = 0;
+   string to = 1;
 }
 
 message PlaceAuctionBid {
-  vault_id string = 0;
-  index int64 = 1;
-  from string = 2;
-  amount string = 3;
+   string vault_id = 0;
+   int64 index = 1;
+   string from = 2;
+   string amount = 3;
 }
 
 message AuctionPagination {
-  start AuctionPaginationStart = 0;
-  including_start bool = 1;
-  limit int64 = 2;
+   AuctionPaginationStart start = 0;
+   bool including_start = 1;
+   int64 limit = 2;
 }
 
 message AuctionPaginationStart {
-  vault_id string = 0;
-  height int64 = 1;
+   string vault_id = 0;
+   int64 height = 1;
 }
 
 message VaultLiquidationBatch {
-  index int64 = 0;
-  collaterals repeated string = 1;
-  loan string = 2;
-  highest_bid HighestBid = 3;
+   int64 index = 0;
+  repeated string collaterals = 1;
+   string loan = 2;
+   HighestBid highest_bid = 3;
 }
 
 message HighestBid {
-  amount string = 0;
-  owner string = 1;
+   string amount = 0;
+   string owner = 1;
 }
 
 message ListAuctionHistoryPagination {
-  max_block_height int64 = 0;
-  vault_id string = 1;
-  index int64 = 2;
-  limit int64 = 3;
+   int64 max_block_height = 0;
+   string vault_id = 1;
+   int64 index = 2;
+   int64 limit = 3;
 }
 
 message ListAuctionHistoryDetail {
-  winner string = 0;
-  block_height int64 = 1;
-  block_hash string = 2;
-  block_time int64 = 3;
-  vault_id string = 4;
-  batch_index int64 = 5;
-  auction_bid string = 6;
-  auction_won repeated string = 7;
+   string winner = 0;
+   int64 block_height = 1;
+   string block_hash = 2;
+   int64 block_time = 3;
+   string vault_id = 4;
+   int64 batch_index = 5;
+   string auction_bid = 6;
+  repeated string auction_won = 7;
 }
 

--- a/example_output_proto
+++ b/example_output_proto
@@ -1,0 +1,223 @@
+message CreateLoanScheme {
+  required min_col_ratio int64 = 0;
+  required interest_rate int64 = 1;
+  required id string = 2;
+}
+
+message UpdateLoanScheme {
+  required min_col_ratio int64 = 0;
+  required interest_rate int64 = 1;
+  required id string = 2;
+  option activate_after_block int64 = 3;
+}
+
+message DestroyLoanScheme {
+  required id string = 0;
+  option activate_after_block int64 = 1;
+}
+
+message LoanSchemeResult {
+  required id string = 0;
+  required mincolratio int64 = 1;
+  required interestrate int64 = 2;
+  required default bool = 3;
+}
+
+message SetCollateralToken {
+  required token string = 0;
+  required factor int64 = 1;
+  required fixed_interval_price_id string = 2;
+  option activate_after_block int64 = 3;
+}
+
+message GetLoanSchemeResult {
+  required id string = 0;
+  required interestrate int64 = 1;
+  required mincolratio int64 = 2;
+  required default bool = 3;
+}
+
+message ListCollateralTokens {
+  option height int64 = 0;
+  option all bool = 1;
+}
+
+message CollateralTokenDetail {
+  required token string = 0;
+  required factor int64 = 1;
+  required fixed_interval_price_id string = 2;
+  required activate_after_block int64 = 3;
+  required token_id string = 4;
+}
+
+message SetLoanToken {
+  required symbol string = 0;
+  option name string = 1;
+  required fixed_interval_price_id string = 2;
+  option mintable bool = 3;
+  option interest int64 = 4;
+}
+
+message LoanConfig {
+  required fixed_interval_blocks int64 = 0;
+  required max_price_deviation_pct int64 = 1;
+  required min_oracles_per_price int64 = 2;
+  required scheme string = 3;
+}
+
+message LoanSummary {
+  required collateral_tokens int64 = 0;
+  required collateral_value int64 = 1;
+  required loan_tokens int64 = 2;
+  required loan_value int64 = 3;
+  required open_auctions int64 = 4;
+  required open_vaults int64 = 5;
+  required schemes int64 = 6;
+}
+
+message GetLoanInfoResult {
+  required current_price_block int64 = 0;
+  required next_price_block int64 = 1;
+  required defaults LoanConfig = 2;
+  required totals LoanSummary = 3;
+}
+
+message UpdateLoanToken {
+  option symbol string = 0;
+  option name string = 1;
+  option fixed_interval_price_id string = 2;
+  option mintable bool = 3;
+  option interest int64 = 4;
+}
+
+message Interest {
+  required token string = 0;
+  required realized_interest_per_block int64 = 1;
+  required total_interest int64 = 2;
+  required interest_per_block int64 = 3;
+}
+
+message CreateVault {
+  required owner_address string = 0;
+  option loan_scheme_id string = 1;
+}
+
+message UpdateVault {
+  option owner_address string = 0;
+  option loan_scheme_id string = 1;
+}
+
+message Vault {
+  required vault_id string = 0;
+  required loan_scheme_id string = 1;
+  required owner_address string = 2;
+  required state VaultState = 3;
+}
+
+message VaultActive {
+  required collateral_amounts repeated string = 0;
+  required loan_amounts repeated string = 1;
+  required interest_amounts repeated string = 2;
+  required collateral_value int64 = 3;
+  required loan_value int64 = 4;
+  required interest_value int64 = 5;
+  required collateral_ratio int64 = 6;
+  required informative_ratio int64 = 7;
+}
+
+message VaultLiquidation {
+  required liquidation_height int64 = 0;
+  required liquidation_penalty int64 = 1;
+  required batch_count int64 = 2;
+  required batches repeated VaultLiquidationBatch = 3;
+}
+
+message UTXO {
+  required txid string = 0;
+  required vout int64 = 1;
+}
+
+message DepositVault {
+  required vault_id string = 0;
+  required from string = 1;
+  required amount string = 2;
+}
+
+message WithdrawVault {
+  required vault_id string = 0;
+  required to string = 1;
+  required amount string = 2;
+}
+
+message PaybackLoanMetadataV2 {
+  required vault_id string = 0;
+  required from string = 1;
+  required loans repeated TokenPaybackAmount = 2;
+}
+
+message VaultPagination {
+  option start string = 0;
+  option including_start bool = 1;
+  option limit int64 = 2;
+}
+
+message ListVaultOptions {
+  option owner_address string = 0;
+  option loan_scheme_id string = 1;
+  option state VaultState = 2;
+  option verbose bool = 3;
+}
+
+message CloseVault {
+  required vault_id string = 0;
+  required to string = 1;
+}
+
+message PlaceAuctionBid {
+  required vault_id string = 0;
+  required index int64 = 1;
+  required from string = 2;
+  required amount string = 3;
+}
+
+message AuctionPagination {
+  option start AuctionPaginationStart = 0;
+  option including_start bool = 1;
+  option limit int64 = 2;
+}
+
+message AuctionPaginationStart {
+  option vault_id string = 0;
+  option height int64 = 1;
+}
+
+message VaultLiquidationBatch {
+  required index int64 = 0;
+  required collaterals repeated string = 1;
+  required loan string = 2;
+  option highest_bid HighestBid = 3;
+}
+
+message HighestBid {
+  required amount string = 0;
+  required owner string = 1;
+}
+
+message ListAuctionHistoryPagination {
+  option max_block_height int64 = 0;
+  option vault_id string = 1;
+  option index int64 = 2;
+  option limit int64 = 3;
+}
+
+message ListAuctionHistoryDetail {
+  required winner string = 0;
+  required block_height int64 = 1;
+  required block_hash string = 2;
+  required block_time int64 = 3;
+  required vault_id string = 4;
+  required batch_index int64 = 5;
+  required auction_bid string = 6;
+  required auction_won repeated string = 7;
+}
+

--- a/example_output_proto
+++ b/example_output_proto
@@ -1,223 +1,223 @@
 message CreateLoanScheme {
-  required min_col_ratio int64 = 0;
-  required interest_rate int64 = 1;
-  required id string = 2;
+  min_col_ratio int64 = 0;
+  interest_rate int64 = 1;
+  id string = 2;
 }
 
 message UpdateLoanScheme {
-  required min_col_ratio int64 = 0;
-  required interest_rate int64 = 1;
-  required id string = 2;
-  option activate_after_block int64 = 3;
+  min_col_ratio int64 = 0;
+  interest_rate int64 = 1;
+  id string = 2;
+  activate_after_block int64 = 3;
 }
 
 message DestroyLoanScheme {
-  required id string = 0;
-  option activate_after_block int64 = 1;
+  id string = 0;
+  activate_after_block int64 = 1;
 }
 
 message LoanSchemeResult {
-  required id string = 0;
-  required mincolratio int64 = 1;
-  required interestrate int64 = 2;
-  required default bool = 3;
+  id string = 0;
+  mincolratio int64 = 1;
+  interestrate int64 = 2;
+  default bool = 3;
 }
 
 message SetCollateralToken {
-  required token string = 0;
-  required factor int64 = 1;
-  required fixed_interval_price_id string = 2;
-  option activate_after_block int64 = 3;
+  token string = 0;
+  factor int64 = 1;
+  fixed_interval_price_id string = 2;
+  activate_after_block int64 = 3;
 }
 
 message GetLoanSchemeResult {
-  required id string = 0;
-  required interestrate int64 = 1;
-  required mincolratio int64 = 2;
-  required default bool = 3;
+  id string = 0;
+  interestrate int64 = 1;
+  mincolratio int64 = 2;
+  default bool = 3;
 }
 
 message ListCollateralTokens {
-  option height int64 = 0;
-  option all bool = 1;
+  height int64 = 0;
+  all bool = 1;
 }
 
 message CollateralTokenDetail {
-  required token string = 0;
-  required factor int64 = 1;
-  required fixed_interval_price_id string = 2;
-  required activate_after_block int64 = 3;
-  required token_id string = 4;
+  token string = 0;
+  factor int64 = 1;
+  fixed_interval_price_id string = 2;
+  activate_after_block int64 = 3;
+  token_id string = 4;
 }
 
 message SetLoanToken {
-  required symbol string = 0;
-  option name string = 1;
-  required fixed_interval_price_id string = 2;
-  option mintable bool = 3;
-  option interest int64 = 4;
+  symbol string = 0;
+  name string = 1;
+  fixed_interval_price_id string = 2;
+  mintable bool = 3;
+  interest int64 = 4;
 }
 
 message LoanConfig {
-  required fixed_interval_blocks int64 = 0;
-  required max_price_deviation_pct int64 = 1;
-  required min_oracles_per_price int64 = 2;
-  required scheme string = 3;
+  fixed_interval_blocks int64 = 0;
+  max_price_deviation_pct int64 = 1;
+  min_oracles_per_price int64 = 2;
+  scheme string = 3;
 }
 
 message LoanSummary {
-  required collateral_tokens int64 = 0;
-  required collateral_value int64 = 1;
-  required loan_tokens int64 = 2;
-  required loan_value int64 = 3;
-  required open_auctions int64 = 4;
-  required open_vaults int64 = 5;
-  required schemes int64 = 6;
+  collateral_tokens int64 = 0;
+  collateral_value int64 = 1;
+  loan_tokens int64 = 2;
+  loan_value int64 = 3;
+  open_auctions int64 = 4;
+  open_vaults int64 = 5;
+  schemes int64 = 6;
 }
 
 message GetLoanInfoResult {
-  required current_price_block int64 = 0;
-  required next_price_block int64 = 1;
-  required defaults LoanConfig = 2;
-  required totals LoanSummary = 3;
+  current_price_block int64 = 0;
+  next_price_block int64 = 1;
+  defaults LoanConfig = 2;
+  totals LoanSummary = 3;
 }
 
 message UpdateLoanToken {
-  option symbol string = 0;
-  option name string = 1;
-  option fixed_interval_price_id string = 2;
-  option mintable bool = 3;
-  option interest int64 = 4;
+  symbol string = 0;
+  name string = 1;
+  fixed_interval_price_id string = 2;
+  mintable bool = 3;
+  interest int64 = 4;
 }
 
 message Interest {
-  required token string = 0;
-  required realized_interest_per_block int64 = 1;
-  required total_interest int64 = 2;
-  required interest_per_block int64 = 3;
+  token string = 0;
+  realized_interest_per_block int64 = 1;
+  total_interest int64 = 2;
+  interest_per_block int64 = 3;
 }
 
 message CreateVault {
-  required owner_address string = 0;
-  option loan_scheme_id string = 1;
+  owner_address string = 0;
+  loan_scheme_id string = 1;
 }
 
 message UpdateVault {
-  option owner_address string = 0;
-  option loan_scheme_id string = 1;
+  owner_address string = 0;
+  loan_scheme_id string = 1;
 }
 
 message Vault {
-  required vault_id string = 0;
-  required loan_scheme_id string = 1;
-  required owner_address string = 2;
-  required state VaultState = 3;
+  vault_id string = 0;
+  loan_scheme_id string = 1;
+  owner_address string = 2;
+  state VaultState = 3;
 }
 
 message VaultActive {
-  required collateral_amounts repeated string = 0;
-  required loan_amounts repeated string = 1;
-  required interest_amounts repeated string = 2;
-  required collateral_value int64 = 3;
-  required loan_value int64 = 4;
-  required interest_value int64 = 5;
-  required collateral_ratio int64 = 6;
-  required informative_ratio int64 = 7;
+  collateral_amounts repeated string = 0;
+  loan_amounts repeated string = 1;
+  interest_amounts repeated string = 2;
+  collateral_value int64 = 3;
+  loan_value int64 = 4;
+  interest_value int64 = 5;
+  collateral_ratio int64 = 6;
+  informative_ratio int64 = 7;
 }
 
 message VaultLiquidation {
-  required liquidation_height int64 = 0;
-  required liquidation_penalty int64 = 1;
-  required batch_count int64 = 2;
-  required batches repeated VaultLiquidationBatch = 3;
+  liquidation_height int64 = 0;
+  liquidation_penalty int64 = 1;
+  batch_count int64 = 2;
+  batches repeated VaultLiquidationBatch = 3;
 }
 
 message UTXO {
-  required txid string = 0;
-  required vout int64 = 1;
+  txid string = 0;
+  vout int64 = 1;
 }
 
 message DepositVault {
-  required vault_id string = 0;
-  required from string = 1;
-  required amount string = 2;
+  vault_id string = 0;
+  from string = 1;
+  amount string = 2;
 }
 
 message WithdrawVault {
-  required vault_id string = 0;
-  required to string = 1;
-  required amount string = 2;
+  vault_id string = 0;
+  to string = 1;
+  amount string = 2;
 }
 
 message PaybackLoanMetadataV2 {
-  required vault_id string = 0;
-  required from string = 1;
-  required loans repeated TokenPaybackAmount = 2;
+  vault_id string = 0;
+  from string = 1;
+  loans repeated TokenPaybackAmount = 2;
 }
 
 message VaultPagination {
-  option start string = 0;
-  option including_start bool = 1;
-  option limit int64 = 2;
+  start string = 0;
+  including_start bool = 1;
+  limit int64 = 2;
 }
 
 message ListVaultOptions {
-  option owner_address string = 0;
-  option loan_scheme_id string = 1;
-  option state VaultState = 2;
-  option verbose bool = 3;
+  owner_address string = 0;
+  loan_scheme_id string = 1;
+  state VaultState = 2;
+  verbose bool = 3;
 }
 
 message CloseVault {
-  required vault_id string = 0;
-  required to string = 1;
+  vault_id string = 0;
+  to string = 1;
 }
 
 message PlaceAuctionBid {
-  required vault_id string = 0;
-  required index int64 = 1;
-  required from string = 2;
-  required amount string = 3;
+  vault_id string = 0;
+  index int64 = 1;
+  from string = 2;
+  amount string = 3;
 }
 
 message AuctionPagination {
-  option start AuctionPaginationStart = 0;
-  option including_start bool = 1;
-  option limit int64 = 2;
+  start AuctionPaginationStart = 0;
+  including_start bool = 1;
+  limit int64 = 2;
 }
 
 message AuctionPaginationStart {
-  option vault_id string = 0;
-  option height int64 = 1;
+  vault_id string = 0;
+  height int64 = 1;
 }
 
 message VaultLiquidationBatch {
-  required index int64 = 0;
-  required collaterals repeated string = 1;
-  required loan string = 2;
-  option highest_bid HighestBid = 3;
+  index int64 = 0;
+  collaterals repeated string = 1;
+  loan string = 2;
+  highest_bid HighestBid = 3;
 }
 
 message HighestBid {
-  required amount string = 0;
-  required owner string = 1;
+  amount string = 0;
+  owner string = 1;
 }
 
 message ListAuctionHistoryPagination {
-  option max_block_height int64 = 0;
-  option vault_id string = 1;
-  option index int64 = 2;
-  option limit int64 = 3;
+  max_block_height int64 = 0;
+  vault_id string = 1;
+  index int64 = 2;
+  limit int64 = 3;
 }
 
 message ListAuctionHistoryDetail {
-  required winner string = 0;
-  required block_height int64 = 1;
-  required block_hash string = 2;
-  required block_time int64 = 3;
-  required vault_id string = 4;
-  required batch_index int64 = 5;
-  required auction_bid string = 6;
-  required auction_won repeated string = 7;
+  winner string = 0;
+  block_height int64 = 1;
+  block_hash string = 2;
+  block_time int64 = 3;
+  vault_id string = 4;
+  batch_index int64 = 5;
+  auction_bid string = 6;
+  auction_won repeated string = 7;
 }
 

--- a/src/class.rs
+++ b/src/class.rs
@@ -6,7 +6,7 @@ use swc_ecma_ast::{
     TsArrayType, TsEntityName, TsType, TsTypeAnn, TsTypeParamInstantiation, TsTypeRef,
 };
 
-use crate::utils::{map_type, Param};
+use crate::utils::{map_type_rust, Param};
 
 fn get_cmd_args(args: Vec<ExprOrSpread>) -> (Option<String>, Vec<String>) {
     let mut it = args.into_iter();
@@ -91,7 +91,7 @@ pub fn handle_class(class: Class) {
                         TsType::TsKeywordType(keyword) => {
                             fn_params.push(Param {
                                 key: id.sym.to_string(),
-                                val: map_type(keyword.kind),
+                                val: map_type_rust(keyword.kind),
                                 optional: id.optional,
                             });
                         }
@@ -170,7 +170,7 @@ pub fn handle_class(class: Class) {
                 {
                     match params.get(0) {
                         Some(box TsType::TsKeywordType(keyword)) => {
-                            fn_return_type = Some(map_type(keyword.kind));
+                            fn_return_type = Some(map_type_rust(keyword.kind));
                         }
                         Some(box TsType::TsArrayType(TsArrayType {
                             elem_type:

--- a/src/class.rs
+++ b/src/class.rs
@@ -6,7 +6,7 @@ use swc_ecma_ast::{
     TsArrayType, TsEntityName, TsType, TsTypeAnn, TsTypeParamInstantiation, TsTypeRef,
 };
 
-use crate::utils::{map_type_rust, ConversionType, Param};
+use crate::utils::{ConversionType, Param};
 
 fn get_cmd_args(args: Vec<ExprOrSpread>) -> (Option<String>, Vec<String>) {
     let mut it = args.into_iter();
@@ -83,6 +83,7 @@ pub fn handle_class(class: Class, conversion_type: ConversionType) {
                             ..
                         }) => {
                             fn_params.push(Param {
+                                prefix: String::from(""),
                                 key: id.sym.to_string(),
                                 val: ident.sym.to_string(),
                                 optional: id.optional,
@@ -91,8 +92,9 @@ pub fn handle_class(class: Class, conversion_type: ConversionType) {
                         }
                         TsType::TsKeywordType(keyword) => {
                             fn_params.push(Param {
+                                prefix: String::from(""),
                                 key: id.sym.to_string(),
-                                val: map_type_rust(keyword.kind),
+                                val: ConversionType::Rust.map_type()(keyword.kind),
                                 optional: id.optional,
                                 conversion_type: conversion_type.get(),
                             });
@@ -119,6 +121,7 @@ pub fn handle_class(class: Class, conversion_type: ConversionType) {
                                 ..
                             }) => {
                                 fn_params.push(Param {
+                                    prefix: String::from(""),
                                     key: id.sym.to_string(),
                                     val: ident.sym.to_string(),
                                     optional: true,
@@ -173,7 +176,7 @@ pub fn handle_class(class: Class, conversion_type: ConversionType) {
                 {
                     match params.get(0) {
                         Some(box TsType::TsKeywordType(keyword)) => {
-                            fn_return_type = Some(map_type_rust(keyword.kind));
+                            fn_return_type = Some(ConversionType::Rust.map_type()(keyword.kind));
                         }
                         Some(box TsType::TsArrayType(TsArrayType {
                             elem_type:

--- a/src/class.rs
+++ b/src/class.rs
@@ -6,7 +6,7 @@ use swc_ecma_ast::{
     TsArrayType, TsEntityName, TsType, TsTypeAnn, TsTypeParamInstantiation, TsTypeRef,
 };
 
-use crate::utils::{map_type_rust, Param};
+use crate::utils::{map_type_rust, ConversionType, Param};
 
 fn get_cmd_args(args: Vec<ExprOrSpread>) -> (Option<String>, Vec<String>) {
     let mut it = args.into_iter();
@@ -53,7 +53,7 @@ fn get_cmd_args(args: Vec<ExprOrSpread>) -> (Option<String>, Vec<String>) {
     (cmd, args)
 }
 
-pub fn handle_class(class: Class) {
+pub fn handle_class(class: Class, conversion_type: ConversionType) {
     for member in class.body {
         let mut fn_name: Option<String> = None;
         let mut fn_params: Vec<Param> = Vec::new();
@@ -86,6 +86,7 @@ pub fn handle_class(class: Class) {
                                 key: id.sym.to_string(),
                                 val: ident.sym.to_string(),
                                 optional: id.optional,
+                                conversion_type: conversion_type.get(),
                             });
                         }
                         TsType::TsKeywordType(keyword) => {
@@ -93,6 +94,7 @@ pub fn handle_class(class: Class) {
                                 key: id.sym.to_string(),
                                 val: map_type_rust(keyword.kind),
                                 optional: id.optional,
+                                conversion_type: conversion_type.get(),
                             });
                         }
                         _ => (),
@@ -120,6 +122,7 @@ pub fn handle_class(class: Class) {
                                     key: id.sym.to_string(),
                                     val: ident.sym.to_string(),
                                     optional: true,
+                                    conversion_type: conversion_type.get(),
                                 });
                                 // fn_has_utxo = true;
                             }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use convert_case::{Case, Casing};
 use swc_ecma_ast::{TsEnumDecl, TsEnumMember, TsEnumMemberId};
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -2,10 +2,7 @@ use std::fmt::Display;
 
 extern crate swc_ecma_parser;
 
-use swc_ecma_ast::{
-    BindingIdent, Expr, TsFnParam, TsIndexSignature, TsInterfaceDecl, TsPropertySignature, TsType,
-    TsTypeAnn, TsTypeElement, TsTypeParamDecl,
-};
+use swc_ecma_ast::{TsInterfaceDecl, TsTypeParamDecl};
 
 use crate::utils::{ConversionType, Param};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod utils;
 
 use class::handle_class;
 use enums::handle_enum;
-use interface::handle_interface;
+use interface::{handle_interface, ConversionType};
 
 use std::path::Path;
 
@@ -23,12 +23,16 @@ use swc_ecma_ast::{ClassDecl, Decl, ModuleItem};
 
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax};
 
-fn transpile(body: Vec<ModuleItem>) {
+fn transpile(body: Vec<ModuleItem>, conversion_type: ConversionType) {
     for item in body {
+        let conversion_type = match conversion_type {
+            ConversionType::Rust => ConversionType::Rust,
+            ConversionType::Protobuf => ConversionType::Protobuf,
+        };
         if let ModuleDecl(ExportDecl(export)) = item {
             match export.decl {
                 Decl::TsInterface(interface) => {
-                    handle_interface(interface);
+                    handle_interface(interface, conversion_type);
                 }
                 Decl::Class(ClassDecl { class, .. }) => {
                     handle_class(class);
@@ -46,10 +50,18 @@ fn main() {
     let cm: Lrc<SourceMap> = Default::default();
     let handler = Handler::with_tty_emitter(ColorConfig::Auto, true, false, Some(cm.clone()));
 
-    let arg = std::env::args().nth(1);
+    let args: Vec<String> = std::env::args().collect();
+    // println!("input file: {}", &args[1]);
+    // println!("conversion type: {}", &args[2]);
+
+    let arg = args[1].as_str();
+    let conversion_type = match args[2].as_str() {
+        "proto" => ConversionType::Protobuf,
+        _ => ConversionType::Rust,
+    };
     let fm = cm
-        .load_file(Path::new(arg.as_ref().unwrap()))
-        .unwrap_or_else(|_| panic!("failed to load {}", arg.as_ref().unwrap()));
+        .load_file(Path::new(&arg))
+        .unwrap_or_else(|_| panic!("failed to load {}", &arg));
 
     let lexer = Lexer::new(
         Syntax::Typescript(Default::default()),
@@ -72,5 +84,5 @@ fn main() {
         })
         .expect("failed to parser module");
 
-    transpile(module.body)
+    transpile(module.body, conversion_type)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,8 @@ mod utils;
 
 use class::handle_class;
 use enums::handle_enum;
-use interface::{handle_interface, ConversionType};
+use interface::handle_interface;
+use utils::ConversionType;
 
 use std::path::Path;
 
@@ -23,9 +24,9 @@ use swc_ecma_ast::{ClassDecl, Decl, ModuleItem};
 
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax};
 
-fn transpile(body: Vec<ModuleItem>, conversion_type: ConversionType) {
+fn transpile(body: Vec<ModuleItem>, con_type: ConversionType) {
     for item in body {
-        let conversion_type = match conversion_type {
+        let conversion_type = match con_type {
             ConversionType::Rust => ConversionType::Rust,
             ConversionType::Protobuf => ConversionType::Protobuf,
         };
@@ -35,7 +36,7 @@ fn transpile(body: Vec<ModuleItem>, conversion_type: ConversionType) {
                     handle_interface(interface, conversion_type);
                 }
                 Decl::Class(ClassDecl { class, .. }) => {
-                    handle_class(class);
+                    handle_class(class, conversion_type);
                 }
                 Decl::TsEnum(_enum) => {
                     handle_enum(_enum);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,9 @@
 use convert_case::{Case, Casing};
 use std::fmt::Display;
 use swc_ecma_ast::{
-    TsArrayType, TsEntityName, TsKeywordType, TsKeywordTypeKind, TsType, TsTypeRef,
+    BindingIdent, Expr, TsArrayType, TsEntityName, TsFnParam, TsIndexSignature, TsInterfaceDecl,
+    TsKeywordType, TsKeywordTypeKind, TsPropertySignature, TsType, TsTypeAnn, TsTypeElement,
+    TsTypeParamDecl, TsTypeRef,
 };
 
 pub enum ConversionType {
@@ -16,28 +18,45 @@ impl ConversionType {
             ConversionType::Rust => ConversionType::Rust,
         }
     }
+    fn map_type_rust(kind: TsKeywordTypeKind) -> String {
+        match kind {
+            TsKeywordTypeKind::TsStringKeyword => String::from("String"),
+            TsKeywordTypeKind::TsNumberKeyword => String::from("u64"),
+            TsKeywordTypeKind::TsBooleanKeyword => String::from("bool"),
+            _ => panic!("MISSING KIND"),
+        }
+    }
+    fn map_type_proto(kind: TsKeywordTypeKind) -> String {
+        match kind {
+            TsKeywordTypeKind::TsStringKeyword => String::from("string"),
+            TsKeywordTypeKind::TsNumberKeyword => String::from("int64"),
+            TsKeywordTypeKind::TsBooleanKeyword => String::from("bool"),
+            _ => panic!("MISSING KIND"),
+        }
+    }
 
     pub fn map_type(&self) -> fn(TsKeywordTypeKind) -> String {
         match self {
-            ConversionType::Rust => map_type_rust,
-            ConversionType::Protobuf => map_type_proto,
+            ConversionType::Rust => ConversionType::map_type_rust,
+            ConversionType::Protobuf => ConversionType::map_type_proto,
         }
     }
-    /*
 
-    */
-    fn map_ts_type_rust(&self, type_ann: TsType) -> String {
+    fn map_ts_type_rust(&self, type_ann: TsType) -> (String, String) {
         match type_ann {
             TsType::TsTypeRef(TsTypeRef {
                 type_name: TsEntityName::Ident(ident),
                 ..
-            }) => self.map_non_ts_keywords(ident.sym.to_string()),
+            }) => (
+                String::from(""),
+                self.map_non_ts_keywords(ident.sym.to_string()),
+            ),
 
-            TsType::TsKeywordType(keyword) => self.map_type()(keyword.kind),
+            TsType::TsKeywordType(keyword) => (String::from(""), self.map_type()(keyword.kind)),
             TsType::TsArrayType(TsArrayType {
                 elem_type: box TsType::TsKeywordType(TsKeywordType { kind, .. }),
                 ..
-            }) => format!("Vec<{}>", self.map_type()(kind)),
+            }) => (String::from(""), format!("Vec<{}>", self.map_type()(kind))),
             TsType::TsArrayType(TsArrayType {
                 elem_type:
                     box TsType::TsTypeRef(TsTypeRef {
@@ -45,26 +64,32 @@ impl ConversionType {
                         ..
                     }),
                 ..
-            }) => format!("Vec<{}>", ident.sym),
+            }) => (String::from(""), format!("Vec<{}>", ident.sym)),
             _ => {
                 // println!("type_ann : {:#?}", type_ann);
                 // panic!("UNINPLEMENTED TSTYPE FOR PROPERTY INTERFACE")
-                format!("UNINPLEMENTED TSTYPE FOR PROPERTY INTERFACE")
+                (
+                    String::from(""),
+                    format!("UNINPLEMENTED TSTYPE FOR PROPERTY INTERFACE"),
+                )
             }
         }
     }
-    fn map_ts_type_proto(&self, type_ann: TsType) -> String {
+    fn map_ts_type_proto(&self, type_ann: TsType) -> (String, String) {
         match type_ann {
             TsType::TsTypeRef(TsTypeRef {
                 type_name: TsEntityName::Ident(ident),
                 ..
-            }) => self.map_non_ts_keywords(ident.sym.to_string()),
+            }) => (
+                String::from(""),
+                self.map_non_ts_keywords(ident.sym.to_string()),
+            ),
 
-            TsType::TsKeywordType(keyword) => self.map_type()(keyword.kind),
+            TsType::TsKeywordType(keyword) => (String::from(""), self.map_type()(keyword.kind)),
             TsType::TsArrayType(TsArrayType {
                 elem_type: box TsType::TsKeywordType(TsKeywordType { kind, .. }),
                 ..
-            }) => format!("repeated {}", self.map_type()(kind)),
+            }) => (String::from("repeated"), self.map_type()(kind)),
             TsType::TsArrayType(TsArrayType {
                 elem_type:
                     box TsType::TsTypeRef(TsTypeRef {
@@ -72,15 +97,18 @@ impl ConversionType {
                         ..
                     }),
                 ..
-            }) => format!("repeated {}", ident.sym),
+            }) => (String::from("repeated"), ident.sym.to_string()),
             _ => {
                 // println!("type_ann : {:#?}", type_ann);
                 // panic!("UNINPLEMENTED TSTYPE FOR PROPERTY INTERFACE")
-                format!("UNINPLEMENTED TSTYPE FOR PROPERTY INTERFACE")
+                (
+                    String::from(""),
+                    format!("UNINPLEMENTED TSTYPE FOR PROPERTY INTERFACE"),
+                )
             }
         }
     }
-    pub fn map_ts_types(&self, type_ann: TsType) -> String {
+    pub fn map_ts_types(&self, type_ann: TsType) -> (String, String) {
         match self {
             ConversionType::Rust => self.map_ts_type_rust(type_ann),
             ConversionType::Protobuf => self.map_ts_type_proto(type_ann),
@@ -98,25 +126,59 @@ impl ConversionType {
             },
         }
     }
-}
-pub fn map_type_rust(kind: TsKeywordTypeKind) -> String {
-    match kind {
-        TsKeywordTypeKind::TsStringKeyword => String::from("String"),
-        TsKeywordTypeKind::TsNumberKeyword => String::from("u64"),
-        TsKeywordTypeKind::TsBooleanKeyword => String::from("bool"),
-        _ => panic!("MISSING KIND"),
-    }
-}
-pub fn map_type_proto(kind: TsKeywordTypeKind) -> String {
-    match kind {
-        TsKeywordTypeKind::TsStringKeyword => String::from("string"),
-        TsKeywordTypeKind::TsNumberKeyword => String::from("int64"),
-        TsKeywordTypeKind::TsBooleanKeyword => String::from("bool"),
-        _ => panic!("MISSING KIND"),
+    pub fn extract_key_value_from_ts_type_element(
+        &self,
+        property: TsTypeElement,
+    ) -> (String, String, String, bool, bool) {
+        match property {
+            TsTypeElement::TsPropertySignature(TsPropertySignature {
+                key: box Expr::Ident(id),
+                type_ann: Some(TsTypeAnn { box type_ann, .. }),
+                optional,
+                ..
+            }) => {
+                let (prefix, value) = self.map_ts_types(type_ann);
+                (prefix, id.sym.to_string(), value, optional, false)
+            }
+            // return (key, val, optional)
+
+            // Handle conversion for hashmap type such as
+            // ```
+            // export interface MasternodeResult<T> {
+            //     [id: string]: T
+            // }
+            // ```
+            // to
+            // ```
+            // pub struct MasternodeResult<T>(HashMap<String, T>);
+            // ```
+            TsTypeElement::TsIndexSignature(TsIndexSignature {
+                params,
+                type_ann: Some(TsTypeAnn { box type_ann, .. }),
+                ..
+            }) => {
+                if let Some(TsFnParam::Ident(BindingIdent {
+                    type_ann:
+                        Some(TsTypeAnn {
+                            type_ann: box TsType::TsKeywordType(keyword),
+                            ..
+                        }),
+                    ..
+                })) = params.get(0)
+                {
+                    let (prefix, value) = self.map_ts_types(type_ann);
+                    return (prefix, self.map_type()(keyword.kind), value, false, true);
+                } else {
+                    unreachable!("found an unexpected ts type!");
+                }
+            }
+            _ => unreachable!("found an unexpected ts type!"),
+        }
     }
 }
 
 pub struct Param {
+    pub prefix: String,
     pub key: String,
     pub val: String,
     pub optional: bool,
@@ -135,7 +197,13 @@ impl Param {
         write!(f, "{},", str)
     }
     fn fmt_proto(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} {}", self.key.to_case(Case::Snake), self.val.clone())
+        write!(
+            f,
+            "{} {} {}",
+            self.prefix,
+            self.key.to_case(Case::Snake),
+            self.val.clone()
+        )
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,8 @@
 use convert_case::{Case, Casing};
 use std::fmt::Display;
 use swc_ecma_ast::{
-    BindingIdent, Expr, TsArrayType, TsEntityName, TsFnParam, TsIndexSignature, TsInterfaceDecl,
-    TsKeywordType, TsKeywordTypeKind, TsPropertySignature, TsType, TsTypeAnn, TsTypeElement,
-    TsTypeParamDecl, TsTypeRef,
+    BindingIdent, Expr, TsArrayType, TsEntityName, TsFnParam, TsIndexSignature, TsKeywordType,
+    TsKeywordTypeKind, TsPropertySignature, TsType, TsTypeAnn, TsTypeElement, TsTypeRef,
 };
 
 pub enum ConversionType {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -200,8 +200,8 @@ impl Param {
             f,
             "{} {} {}",
             self.prefix,
+            self.val.clone(),
             self.key.to_case(Case::Snake),
-            self.val.clone()
         )
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,104 @@
 use convert_case::{Case, Casing};
 use std::fmt::Display;
-use swc_ecma_ast::TsKeywordTypeKind;
+use swc_ecma_ast::{
+    TsArrayType, TsEntityName, TsKeywordType, TsKeywordTypeKind, TsType, TsTypeRef,
+};
 
+pub enum ConversionType {
+    Rust,
+    Protobuf,
+}
+
+impl ConversionType {
+    pub fn get(&self) -> ConversionType {
+        match self {
+            ConversionType::Protobuf => ConversionType::Protobuf,
+            ConversionType::Rust => ConversionType::Rust,
+        }
+    }
+
+    pub fn map_type(&self) -> fn(TsKeywordTypeKind) -> String {
+        match self {
+            ConversionType::Rust => map_type_rust,
+            ConversionType::Protobuf => map_type_proto,
+        }
+    }
+    /*
+
+    */
+    fn map_ts_type_rust(&self, type_ann: TsType) -> String {
+        match type_ann {
+            TsType::TsTypeRef(TsTypeRef {
+                type_name: TsEntityName::Ident(ident),
+                ..
+            }) => self.map_non_ts_keywords(ident.sym.to_string()),
+
+            TsType::TsKeywordType(keyword) => self.map_type()(keyword.kind),
+            TsType::TsArrayType(TsArrayType {
+                elem_type: box TsType::TsKeywordType(TsKeywordType { kind, .. }),
+                ..
+            }) => format!("Vec<{}>", self.map_type()(kind)),
+            TsType::TsArrayType(TsArrayType {
+                elem_type:
+                    box TsType::TsTypeRef(TsTypeRef {
+                        type_name: TsEntityName::Ident(ident),
+                        ..
+                    }),
+                ..
+            }) => format!("Vec<{}>", ident.sym),
+            _ => {
+                // println!("type_ann : {:#?}", type_ann);
+                // panic!("UNINPLEMENTED TSTYPE FOR PROPERTY INTERFACE")
+                format!("UNINPLEMENTED TSTYPE FOR PROPERTY INTERFACE")
+            }
+        }
+    }
+    fn map_ts_type_proto(&self, type_ann: TsType) -> String {
+        match type_ann {
+            TsType::TsTypeRef(TsTypeRef {
+                type_name: TsEntityName::Ident(ident),
+                ..
+            }) => self.map_non_ts_keywords(ident.sym.to_string()),
+
+            TsType::TsKeywordType(keyword) => self.map_type()(keyword.kind),
+            TsType::TsArrayType(TsArrayType {
+                elem_type: box TsType::TsKeywordType(TsKeywordType { kind, .. }),
+                ..
+            }) => format!("repeated {}", self.map_type()(kind)),
+            TsType::TsArrayType(TsArrayType {
+                elem_type:
+                    box TsType::TsTypeRef(TsTypeRef {
+                        type_name: TsEntityName::Ident(ident),
+                        ..
+                    }),
+                ..
+            }) => format!("repeated {}", ident.sym),
+            _ => {
+                // println!("type_ann : {:#?}", type_ann);
+                // panic!("UNINPLEMENTED TSTYPE FOR PROPERTY INTERFACE")
+                format!("UNINPLEMENTED TSTYPE FOR PROPERTY INTERFACE")
+            }
+        }
+    }
+    pub fn map_ts_types(&self, type_ann: TsType) -> String {
+        match self {
+            ConversionType::Rust => self.map_ts_type_rust(type_ann),
+            ConversionType::Protobuf => self.map_ts_type_proto(type_ann),
+        }
+    }
+    pub fn map_non_ts_keywords(&self, keyword: String) -> String {
+        match self {
+            ConversionType::Rust => match keyword.as_str() {
+                "BigNumber" => String::from("Decimal"),
+                _ => keyword,
+            },
+            ConversionType::Protobuf => match keyword.as_str() {
+                "BigNumber" => String::from("int64"),
+                _ => keyword,
+            },
+        }
+    }
+}
 pub fn map_type_rust(kind: TsKeywordTypeKind) -> String {
     match kind {
         TsKeywordTypeKind::TsStringKeyword => String::from("String"),
@@ -23,10 +120,11 @@ pub struct Param {
     pub key: String,
     pub val: String,
     pub optional: bool,
+    pub conversion_type: ConversionType,
 }
 
-impl Display for Param {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Param {
+    fn fmt_rust(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let val = self.val.clone();
         let opt_val = if self.optional {
             format!("Option<{}>", val)
@@ -35,5 +133,17 @@ impl Display for Param {
         };
         let str = format!("{}: {}", self.key.to_case(Case::Snake), opt_val);
         write!(f, "{},", str)
+    }
+    fn fmt_proto(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} {}", self.key.to_case(Case::Snake), self.val.clone())
+    }
+}
+
+impl Display for Param {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.conversion_type {
+            ConversionType::Protobuf => self.fmt_proto(f),
+            ConversionType::Rust => self.fmt_rust(f),
+        }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,10 +2,18 @@ use convert_case::{Case, Casing};
 use std::fmt::Display;
 use swc_ecma_ast::TsKeywordTypeKind;
 
-pub fn map_type(kind: TsKeywordTypeKind) -> String {
+pub fn map_type_rust(kind: TsKeywordTypeKind) -> String {
     match kind {
         TsKeywordTypeKind::TsStringKeyword => String::from("String"),
         TsKeywordTypeKind::TsNumberKeyword => String::from("u64"),
+        TsKeywordTypeKind::TsBooleanKeyword => String::from("bool"),
+        _ => panic!("MISSING KIND"),
+    }
+}
+pub fn map_type_proto(kind: TsKeywordTypeKind) -> String {
+    match kind {
+        TsKeywordTypeKind::TsStringKeyword => String::from("string"),
+        TsKeywordTypeKind::TsNumberKeyword => String::from("int64"),
         TsKeywordTypeKind::TsBooleanKeyword => String::from("bool"),
         _ => panic!("MISSING KIND"),
     }


### PR DESCRIPTION
### Ready for review
- fix commas, after every attribute in the proto message.
- remove `required` and `optional` from the fields since proto3 makes
  all the fields optional.
- refactor out transformation code from interface to utils.
- fix the issue with `repeated` appearing in between key and value.